### PR TITLE
Avoid $PREFIX/lib64 use

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -624,7 +624,7 @@ else(BITS EQUAL 64)
 	)
 endif(BITS EQUAL 64)
 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib${SUFFIX}/darling")
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/darling")
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) 
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -634,4 +634,4 @@ target_link_libraries(crypto098 system)
 add_library(ssl098 SHARED ${ssl_sources})
 target_link_libraries(ssl098 system crypto098)
 
-install(TARGETS ssl098 crypto098 DESTINATION lib${SUFFIX}/darling)
+install(TARGETS ssl098 crypto098 DESTINATION ${CMAKE_INSTALL_LIBDIR}/darling)


### PR DESCRIPTION
Since darlinghq/darling@5fb8d71, Pacman complains about this. Let's fix this.